### PR TITLE
fix: Prevent punishments from proceeding even if the log message has been deleted

### DIFF
--- a/src/interaction-handlers/selectmenus/RuleSelect.ts
+++ b/src/interaction-handlers/selectmenus/RuleSelect.ts
@@ -55,6 +55,12 @@ export class RuleSelect extends InteractionHandler {
     } else if (parsedData.commandName === "punish") {
       await MutexManager.getUserMutex(parsedData.targetMemberId).runExclusive(
         async () => {
+          if (parsedData.logMessageId != null) {
+            if (ViolationService.handled.includes(parsedData.logMessageId)) {
+              await replyInteractionError(interaction, "Log has already been handled.");
+              return;
+            }
+          }
           const logMessage =
             parsedData.logMessageId != null
               ? await TryVal(
@@ -63,12 +69,6 @@ export class RuleSelect extends InteractionHandler {
                   ),
                 )
               : null;
-          if (logMessage != null) {
-            if (ViolationService.handled.includes(logMessage.id)) {
-              await replyInteractionError(interaction, "Log has already been handled.");
-              return;
-            }
-          }
           if (interaction.guild == null || interaction.member == null) {
             return;
           }


### PR DESCRIPTION
Check ValiationService.handled as the very first thing that happens in the punish execution flow. 
Use parsedData.logMessageId instead of fetching the message, so that if the message has been deleted since the moderator started the punish workflow, the failing fetch does not cause the ValidationService check to be skipped.