### PR TITLE
Add additional configuration Constants for emote reports; decrease emote-report score threshold

### DIFF
--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -141,12 +141,12 @@ export async function checkEmotes(message: Message, reaction: MessageReaction) {
         score +=
           Constants.EMOTE_SCORES.find((val) => val.id === user.id)?.score ?? 0.05;
       });
-      if (score >= 0.25) {
+      if (score >= Constants.EMOTE_REPORT_THRESHOLD_SCORE) {
         const fieldsAndValues = [
           "Action",
           `Emote Report [Jump to message](${message.url})`,
           "Score",
-          `${score.toString()} >= 0.25`,
+          `${score.toString()} >= ${Constants.EMOTE_REPORT_THRESHOLD_SCORE.toString()}`,
           "Channel",
           message.channel.toString(),
         ];

--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -139,7 +139,7 @@ export async function checkEmotes(message: Message, reaction: MessageReaction) {
         ?.users.fetch();
       users?.forEach((user) => {
         score +=
-          Constants.EMOTE_SCORES.find((val) => val.id === user.id)?.score ?? 0.05;
+          Constants.EMOTE_REPORT_ROLE_SCORES.find((val) => val.id === user.id)?.score ?? 0.05;
       });
       if (score >= Constants.EMOTE_REPORT_THRESHOLD_SCORE) {
         const fieldsAndValues = [

--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -139,7 +139,8 @@ export async function checkEmotes(message: Message, reaction: MessageReaction) {
         ?.users.fetch();
       users?.forEach((user) => {
         score +=
-          Constants.EMOTE_REPORT_ROLE_SCORES.find((val) => val.id === user.id)?.score ?? 0.05;
+          Constants.EMOTE_REPORT_ROLE_SCORES.find((val) => val.id === user.id)?.score
+          ?? Constants.EMOTE_REPORT_ROLELESS_SCORE;
       });
       if (score >= Constants.EMOTE_REPORT_THRESHOLD_SCORE) {
         const fieldsAndValues = [

--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -132,10 +132,10 @@ export async function checkEmotes(message: Message, reaction: MessageReaction) {
     ) {
       return;
     }
-    if (reaction.emoji.id === Constants.EMOTE_ID) {
+    if (reaction.emoji.id === Constants.EMOTE_REPORT_EMOTE_ID) {
       let score = 0;
       const users = await message.reactions.cache
-        .find((msgReaction) => msgReaction.emoji.id === Constants.EMOTE_ID)
+        .find((msgReaction) => msgReaction.emoji.id === Constants.EMOTE_REPORT_EMOTE_ID)
         ?.users.fetch();
       users?.forEach((user) => {
         score +=

--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -139,8 +139,8 @@ export async function checkEmotes(message: Message, reaction: MessageReaction) {
         ?.users.fetch();
       users?.forEach((user) => {
         score +=
-          Constants.EMOTE_REPORT_ROLE_SCORES.find((val) => val.id === user.id)?.score
-          ?? Constants.EMOTE_REPORT_ROLELESS_SCORE;
+          Constants.EMOTE_REPORT_ROLE_SCORES.find((val) => val.id === user.id)?.score ??
+          Constants.EMOTE_REPORT_ROLELESS_SCORE;
       });
       if (score >= Constants.EMOTE_REPORT_THRESHOLD_SCORE) {
         const fieldsAndValues = [

--- a/src/utility/Constants.ts
+++ b/src/utility/Constants.ts
@@ -111,6 +111,8 @@ export class Constants {
     { id: "313677111695245312", score: 0.1 },
   ];
 
+  static readonly EMOTE_REPORT_THRESHOLD_SCORE = 0.25;
+
   static readonly BOTS = {
     MOD_MAIL: "797143867048591370",
   };

--- a/src/utility/Constants.ts
+++ b/src/utility/Constants.ts
@@ -104,7 +104,7 @@ export class Constants {
 
   static readonly EMOTE_REPORT_EMOTE_ID = "299650191835922432";
 
-  static readonly EMOTE_SCORES: Array<{ id: Snowflake; score: number }> = [
+  static readonly EMOTE_REPORT_ROLE_SCORES: Array<{ id: Snowflake; score: number }> = [
     { id: "314910132733739009", score: 0.4 },
     { id: "314910011358707712", score: 0.3 },
     { id: "314909797445271564", score: 0.2 },

--- a/src/utility/Constants.ts
+++ b/src/utility/Constants.ts
@@ -105,10 +105,10 @@ export class Constants {
   static readonly EMOTE_REPORT_EMOTE_ID = "299650191835922432";
 
   static readonly EMOTE_REPORT_ROLE_SCORES: Array<{ id: Snowflake; score: number }> = [
-    { id: "314910132733739009", score: 40 },
-    { id: "314910011358707712", score: 30 },
-    { id: "314909797445271564", score: 20 },
-    { id: "313677111695245312", score: 10 },
+    { id: "314910132733739009", score: 40 }, // F1
+    { id: "314910011358707712", score: 30 }, // F2
+    { id: "314909797445271564", score: 20 }, // F3
+    { id: "313677111695245312", score: 10 }, // F4
   ];
 
   static readonly EMOTE_REPORT_ROLELESS_SCORE = 5;

--- a/src/utility/Constants.ts
+++ b/src/utility/Constants.ts
@@ -113,7 +113,7 @@ export class Constants {
 
   static readonly EMOTE_REPORT_ROLELESS_SCORE = 5;
 
-  static readonly EMOTE_REPORT_THRESHOLD_SCORE = 25;
+  static readonly EMOTE_REPORT_THRESHOLD_SCORE = 15;
 
   static readonly BOTS = {
     MOD_MAIL: "797143867048591370",

--- a/src/utility/Constants.ts
+++ b/src/utility/Constants.ts
@@ -111,6 +111,8 @@ export class Constants {
     { id: "313677111695245312", score: 0.1 },
   ];
 
+  static readonly EMOTE_REPORT_ROLELESS_SCORE = 0.05;
+
   static readonly EMOTE_REPORT_THRESHOLD_SCORE = 0.25;
 
   static readonly BOTS = {

--- a/src/utility/Constants.ts
+++ b/src/utility/Constants.ts
@@ -102,7 +102,7 @@ export class Constants {
     },
   ];
 
-  static readonly EMOTE_ID = "299650191835922432";
+  static readonly EMOTE_REPORT_EMOTE_ID = "299650191835922432";
 
   static readonly EMOTE_SCORES: Array<{ id: Snowflake; score: number }> = [
     { id: "314910132733739009", score: 0.4 },

--- a/src/utility/Constants.ts
+++ b/src/utility/Constants.ts
@@ -105,15 +105,15 @@ export class Constants {
   static readonly EMOTE_REPORT_EMOTE_ID = "299650191835922432";
 
   static readonly EMOTE_REPORT_ROLE_SCORES: Array<{ id: Snowflake; score: number }> = [
-    { id: "314910132733739009", score: 0.4 },
-    { id: "314910011358707712", score: 0.3 },
-    { id: "314909797445271564", score: 0.2 },
-    { id: "313677111695245312", score: 0.1 },
+    { id: "314910132733739009", score: 40 },
+    { id: "314910011358707712", score: 30 },
+    { id: "314909797445271564", score: 20 },
+    { id: "313677111695245312", score: 10 },
   ];
 
-  static readonly EMOTE_REPORT_ROLELESS_SCORE = 0.05;
+  static readonly EMOTE_REPORT_ROLELESS_SCORE = 5;
 
-  static readonly EMOTE_REPORT_THRESHOLD_SCORE = 0.25;
+  static readonly EMOTE_REPORT_THRESHOLD_SCORE = 25;
 
   static readonly BOTS = {
     MOD_MAIL: "797143867048591370",


### PR DESCRIPTION
We haven't been getting too many emote reports in the queue lately, but there've been several messages that got black-flagged but just didn't meet the score threshold necessary to generate an emote report.

I suggested lowering the score threshold but keeping the existing role score values; this got a thumbs-up, so I'm filing a PR to implement that change.

Additionally, two new constants have been added to Constants.ts: one to specify the score value for users that do not have any of the emote-report roles (i.e. F1/F2/F3/F4), and another to specify the value of the score threshold to generate an emote report.

Lastly, the score values have been converted from decimals to integers (keeping the same relative values but multiplying all of them by `100`), per some comments that it would be slightly more intuitive.