### PR TITLE
add .editorconfig for easier collaboration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{js,ts,json,jsonc}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
My default config is a indent of 4 width, but with the `.editorconfig` file most editors will pick this up and override their behavior to fit the desired settings.